### PR TITLE
Added support for intervals every x weeks

### DIFF
--- a/ScheduleWidget/ScheduleWidget.UnitTest/WeeklyTests.cs
+++ b/ScheduleWidget/ScheduleWidget.UnitTest/WeeklyTests.cs
@@ -54,5 +54,55 @@ namespace ScheduleWidget.UnitTest
             Assert.IsFalse(schedule.IsOccurring(new DateTime(2013, 2, 5))); // Tue
             Assert.IsFalse(schedule.IsOccurring(new DateTime(2014, 7, 5))); // Sat
         }
+
+        [Test]
+        public void WeeklyEventTest3()
+        {
+            var aEvent = new Event()
+            {
+                ID = 1,
+                Title = "Every 2nd week on Mon Wed Fri",
+                Frequency = 2,        // weekly
+                MonthlyInterval = 0,  // not applicable
+                DaysOfWeek = 44,      // every Tue, Wed and Fri
+                WeeklyInterval = 2, // every 2nd week
+                FirstDateTime = new DateTime(2013, 1, 1) // start date on a Tue
+            };
+
+            var schedule = new Schedule(aEvent);
+
+            Assert.IsTrue(schedule.IsOccurring(new DateTime(2013, 1, 1)));
+            Assert.IsTrue(schedule.IsOccurring(new DateTime(2013, 1, 15)));
+            Assert.IsTrue(schedule.IsOccurring(new DateTime(2013, 2, 12)));
+            Assert.IsTrue(schedule.IsOccurring(new DateTime(2013, 12, 17)));
+            Assert.IsTrue(schedule.IsOccurring(new DateTime(2014, 1, 14)));
+
+            Assert.IsFalse(schedule.IsOccurring(new DateTime(2013, 1, 8))); // 1st week
+            Assert.IsFalse(schedule.IsOccurring(new DateTime(2013, 1, 14))); // 2nd week but Mon
+        }
+
+        [Test]
+        public void WeeklyEventTest4()
+        {
+            var aEvent = new Event()
+            {
+                ID = 1,
+                Title = "Every 3rd week on Mon Wed Fri",
+                Frequency = 2,        // weekly
+                MonthlyInterval = 0,  // not applicable
+                DaysOfWeek = 44,      // every Tue, Wed and Fri
+                WeeklyInterval = 3, // every 2nd week
+                FirstDateTime = new DateTime(2013, 1, 1) // start date on a Tue
+            };
+
+            var schedule = new Schedule(aEvent);
+
+            Assert.IsTrue(schedule.IsOccurring(new DateTime(2013, 1, 1)));
+            Assert.IsTrue(schedule.IsOccurring(new DateTime(2013, 1, 22)));
+
+            Assert.IsFalse(schedule.IsOccurring(new DateTime(2013, 1, 8))); // 1st week
+            Assert.IsFalse(schedule.IsOccurring(new DateTime(2013, 1, 15))); // 2nd week
+            Assert.IsFalse(schedule.IsOccurring(new DateTime(2013, 1, 21))); // 3rd week but Mon
+        }
     }
 }

--- a/ScheduleWidget/ScheduleWidget/ScheduleWidget.csproj
+++ b/ScheduleWidget/ScheduleWidget/ScheduleWidget.csproj
@@ -58,6 +58,7 @@
     <Compile Include="ScheduledEvents\FrequencyBuilder\IEventFrequencyBuilder.cs" />
     <Compile Include="ScheduledEvents\WeekInRange.cs" />
     <Compile Include="TemporalExpressions\CollectionTE.cs" />
+    <Compile Include="TemporalExpressions\DayInWeekTE.cs" />
     <Compile Include="TemporalExpressions\DayOfWeekTE.cs" />
     <Compile Include="TemporalExpressions\FloatingHolidayTE.cs" />
     <Compile Include="TemporalExpressions\DateTE.cs" />

--- a/ScheduleWidget/ScheduleWidget/ScheduledEvents/Event.cs
+++ b/ScheduleWidget/ScheduleWidget/ScheduledEvents/Event.cs
@@ -28,6 +28,11 @@ namespace ScheduleWidget.ScheduledEvents
         public DateTime? OneTimeOnlyEventDate { get; set; }
 
         /// <summary>
+        /// If this is a event that repeats every x weeks set the date
+        /// </summary>
+        public DateTime? FirstDateTime { get; set; }
+
+        /// <summary>
         /// For events that occur only part of the year (optional)
         /// </summary>
         public RangeInYear RangeInYear { get; set; }
@@ -44,6 +49,13 @@ namespace ScheduleWidget.ScheduledEvents
         /// E.g., the first and third weeks of the month == 5
         /// </summary>
         public int MonthlyInterval { get; set; }
+
+        /// <summary>
+        /// If the frequency is weekly then the interval of the
+        /// event as an int.
+        /// E.g., every second week == 2
+        /// </summary>
+        public int WeeklyInterval { get; set; }
 
         /// <summary>
         /// The days of the week that the event occurs as a value
@@ -79,6 +91,21 @@ namespace ScheduleWidget.ScheduledEvents
             set
             {
                 MonthlyInterval = (int)value;
+            }
+        }
+
+        /// <summary>
+        /// The monthly interval expressed as enumeration
+        /// </summary>
+        public int WeeklyIntervalOptions
+        {
+            get
+            {
+                return WeeklyInterval;
+            }
+            set
+            {
+                WeeklyInterval = value;
             }
         }
 

--- a/ScheduleWidget/ScheduleWidget/ScheduledEvents/FrequencyBuilder/ConcreteBuilders/WeeklyEventBuilder.cs
+++ b/ScheduleWidget/ScheduleWidget/ScheduledEvents/FrequencyBuilder/ConcreteBuilders/WeeklyEventBuilder.cs
@@ -17,11 +17,24 @@ namespace ScheduleWidget.ScheduledEvents.FrequencyBuilder.ConcreteBuilders
         {
             var union = new UnionTE();
             var daysOfWeek = EnumExtensions.GetFlags(_event.DaysOfWeekOptions);
-            foreach (DayOfWeekEnum day in daysOfWeek)
+            var weeklyIntervals = _event.WeeklyIntervalOptions;
+            if (weeklyIntervals > 1 && _event.FirstDateTime != null)
             {
-                var dayOfWeek = new DayOfWeekTE(day);
-                union.Add(dayOfWeek);
+                foreach (DayOfWeekEnum day in daysOfWeek)
+                {
+                    var dayOfWeek = new DayInWeekTE(day, (DateTime)_event.FirstDateTime, weeklyIntervals);
+                    union.Add(dayOfWeek);
+                }
             }
+            else
+            {
+                foreach (DayOfWeekEnum day in daysOfWeek)
+                {
+                    var dayOfWeek = new DayOfWeekTE(day);
+                    union.Add(dayOfWeek);
+                }
+            }
+
             return union;
         }
     }

--- a/ScheduleWidget/ScheduleWidget/TemporalExpressions/DayInWeekTE.cs
+++ b/ScheduleWidget/ScheduleWidget/TemporalExpressions/DayInWeekTE.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using ScheduleWidget.Enums;
+
+namespace ScheduleWidget.TemporalExpressions
+{
+    /// <summary>
+    /// Compares two specific days of week exactly
+    /// </summary>
+    public class DayInWeekTE : TemporalExpression
+    {
+        private readonly DayOfWeekEnum _dayOfWeek;
+        private readonly DateTime _firstDayOfWeek;
+        private readonly int _weeklyIntervals;
+
+        /// <summary>
+        /// The day of week value
+        /// </summary>
+        /// <param name="aDayOfWeek"></param>
+        public DayInWeekTE(DayOfWeekEnum aDayOfWeek, DateTime aFirstDateTime, int aWeeklyInterval)
+        {
+            _dayOfWeek = aDayOfWeek;
+             _firstDayOfWeek = StartOfWeek(aFirstDateTime, DayOfWeek.Sunday);
+            _weeklyIntervals = aWeeklyInterval;
+        }
+
+        /// <summary>
+        /// Returns true if the weekly interval and the day matches.
+        /// </summary>
+        /// <param name="aDate"></param>
+        /// <returns></returns>
+        public override bool Includes(DateTime aDate)
+        {
+            return WeekMatches(aDate) && DayMatches(aDate);
+        }
+       
+        /// <summary>
+        /// Returns if the day matches the specified day of week.
+        /// </summary>
+        /// <param name="dt"></param>
+        /// <returns></returns>
+        protected bool DayMatches(DateTime aDate)
+        {
+            switch (aDate.DayOfWeek)
+            {
+                case DayOfWeek.Sunday:
+                    return ((int)_dayOfWeek == 1);
+
+                case DayOfWeek.Monday:
+                    return ((int)_dayOfWeek == 2);
+
+                case DayOfWeek.Tuesday:
+                    return ((int)_dayOfWeek == 4);
+
+                case DayOfWeek.Wednesday:
+                    return ((int)_dayOfWeek == 8);
+
+                case DayOfWeek.Thursday:
+                    return ((int)_dayOfWeek == 16);
+
+                case DayOfWeek.Friday:
+                    return ((int)_dayOfWeek == 32);
+
+                case DayOfWeek.Saturday:
+                    return ((int)_dayOfWeek == 64);
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the date falls in a week that matches the weekly interval.
+        /// </summary>
+        /// <param name="dt"></param>
+        /// <returns></returns>
+        protected bool WeekMatches(DateTime aDate)
+        {
+            var startOfWeek = StartOfWeek(aDate, DayOfWeek.Sunday);
+            double weeks = Math.Round((startOfWeek - _firstDayOfWeek).TotalDays / 7);
+
+            if (weeks % _weeklyIntervals == 0)
+            {
+                var endOfWeek = startOfWeek.AddDays(7);
+
+                if (aDate >= startOfWeek && aDate <= endOfWeek)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the first day of the week based on the provided starting day.
+        /// </summary>
+        /// <param name="dt"></param>
+        /// <returns></returns>
+        protected DateTime StartOfWeek(DateTime dt, DayOfWeek startOfWeek)
+        {
+            int diff = dt.DayOfWeek - startOfWeek;
+            if (diff < 0)
+            {
+                diff += 7;
+            }
+
+            return dt.AddDays(-1 * diff).Date;
+        }
+    }
+}


### PR DESCRIPTION
This adds support for weekly intervals e.g. every second or third week. You should be able to use it like this:

var aEvent = new Event()
            {
                Frequency = 2,        // weekly
                DaysOfWeek =  4,      // every Tue
                WeeklyInterval = 2, // every 2nd week
                FirstDateTime = new DateTime(2013, 1, 1)  // start date of the event
            };

Thought you would like this. :)
